### PR TITLE
Fix `throttle` function name in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Restricts the amount of packets sent over the network in a specific threshold ti
   - **threshold** `object` - Limit threshold time frame in miliseconds. Default to `100`
 
 ```js
-toxy.poison(toxy.poisons.slowRead({ chunk: 2048, threshold: 1000 }))
+toxy.poison(toxy.poisons.throttle({ chunk: 2048, threshold: 1000 }))
 ```
 
 #### Abort connection


### PR DESCRIPTION
Minor update to correct wrong function name used in documentation