### PR TITLE
Don't depend on global state

### DIFF
--- a/lib/toxy.js
+++ b/lib/toxy.js
@@ -17,7 +17,7 @@ module.exports = Toxy
 function Toxy (opts) {
   if (!(this instanceof Toxy)) return new Toxy(opts)
 
-  opts = Object.assign(Toxy.defaults, opts)
+  opts = Object.assign({}, Toxy.defaults, opts)
   Proxy.call(this, opts)
 
   this.routes = []


### PR DESCRIPTION
Currently toxy options is a global object, so it is impossible to create more than one toxy instances with different options. Create a new options object for each instance of toxy instead of using the same global object for each instance. I don't know toxy code base at all, so I have no idea about unwanted side effects of this proposal.

